### PR TITLE
Step 5: Enabl OIDC in backend and provider blocks

### DIFF
--- a/infra/tf-app/terraform.tf
+++ b/infra/tf-app/terraform.tf
@@ -4,6 +4,7 @@ terraform {
     storage_account_name = "sing1249githubactions1"
     container_name       = "tfstate"
     key                  = "prod.app.tfstate"
+    use_oidc             = true 
   }
 
   required_providers {
@@ -16,4 +17,5 @@ terraform {
 
 provider "azurerm" {
   features {}
+  use_oidc = true
 }


### PR DESCRIPTION
Enabled use_oidc = true in both the backend and provider blocks in terraform.tf to allow secure authentication with Azure using GitHub Actions.